### PR TITLE
Finalize Migration B: regenerate types, drop transition note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,7 @@ Business logic lives under `src/server/` and runs inside the React Router server
 
 HTTP surface: resource routes in `src/routes/api.*.ts` (`/api/grocery-lists/:listId/recipes`, `/api/grocery-lists/:listId/items`, `/api/recipes/:recipeId`, `/api/cron/cleanup-anonymous-users`). They authenticate via `getUser()`, verify list ownership for clean 404s, and validate bodies. The cron route is guarded by `CRON_SECRET` (Vercel cron sends it as a bearer token; schedule in `vercel.json`).
 
-What intentionally remains in Postgres: RLS policies on every table, `handle_new_anonymous_user` (auth.users trigger), `delete_old_anonymous_users` (called by the cron), and the `replace_generated_grocery_list_items` wrapper. Schema changes go through `supabase/migrations/` as new timestamped files, applied with `supabase db push`.
-
-> Transition note: legacy SQL functions/triggers coexist until `supabase/migrations/20260611130000_drop_ported_postgres_logic.sql` (Migration B) is applied post-deploy. After applying it, run `npm run gen-types` and delete this note.
+What intentionally remains in Postgres: RLS policies on every table, `handle_new_anonymous_user` (auth.users trigger), `delete_old_anonymous_users` (called by the cron), and the `replace_generated_grocery_list_items` wrapper. Schema changes go through `supabase/migrations/` as new timestamped files, applied with `supabase db push`./
 
 ### Feature-sliced layout
 Code is organized by feature under `src/features/<feature>/` (`auth`, `home`, `recipes`, `grocery-lists`), each with its own `components/`, `hooks/`, `pages/`, `types.ts`. The `auth` feature owns `AuthContext.tsx`: Google One Tap, email, anonymous/guest sign-in, password reset, the `initialUser` SSR seed, loader revalidation on sign-in/out, and a one-time localStorage→cookie session migration shim. Shared code lives in `src/components/`, `src/hooks/`, `src/lib/`, `src/utils/` (`constants.ts` has routes, validation, error copy, colors). `@/*` aliases `src/*` — prefer it for cross-folder imports.

--- a/src/types/database-types.ts
+++ b/src/types/database-types.ts
@@ -328,6 +328,7 @@ export type Database = {
         Row: {
           abbreviation: string
           base_conversion_factor: number | null
+          cooking_priority: number | null
           created_at: string | null
           id: string
           name: string
@@ -337,6 +338,7 @@ export type Database = {
         Insert: {
           abbreviation?: string
           base_conversion_factor?: number | null
+          cooking_priority?: number | null
           created_at?: string | null
           id?: string
           name: string
@@ -346,6 +348,7 @@ export type Database = {
         Update: {
           abbreviation?: string
           base_conversion_factor?: number | null
+          cooking_priority?: number | null
           created_at?: string | null
           id?: string
           name?: string
@@ -354,114 +357,19 @@ export type Database = {
         }
         Relationships: []
       }
-      units_backup_before_fix: {
-        Row: {
-          abbreviation: string | null
-          base_conversion_factor: number | null
-          created_at: string | null
-          display_order: number | null
-          id: string | null
-          name: string | null
-          system: string | null
-          type: string | null
-        }
-        Insert: {
-          abbreviation?: string | null
-          base_conversion_factor?: number | null
-          created_at?: string | null
-          display_order?: number | null
-          id?: string | null
-          name?: string | null
-          system?: string | null
-          type?: string | null
-        }
-        Update: {
-          abbreviation?: string | null
-          base_conversion_factor?: number | null
-          created_at?: string | null
-          display_order?: number | null
-          id?: string | null
-          name?: string | null
-          system?: string | null
-          type?: string | null
-        }
-        Relationships: []
-      }
     }
     Views: {
       [_ in never]: never
     }
     Functions: {
-      add_manual_item_to_grocery_list: {
-        Args: {
-          ingredient_name: string
-          list_id: string
-          notes?: string
-          quantity: number
-          unit_name: string
-        }
-        Returns: string
-      }
-      add_recipe_to_grocery_list: {
-        Args: {
-          list_id: string
-          p_recipe_id: string
-          servings_multiplier?: number
-        }
-        Returns: boolean
-      }
       delete_old_anonymous_users: {
-        Args: Record<PropertyKey, never>
+        Args: never
         Returns: {
           deleted_count: number
         }[]
       }
-      find_best_unit_for_quantity: {
-        Args: {
-          p_base_quantity: number
-          p_preferred_system?: string
-          p_unit_type: string
-        }
-        Returns: string
-      }
-      generate_simple_anonymous_username: {
-        Args: Record<PropertyKey, never>
-        Returns: string
-      }
-      get_public_and_user_recipes: {
-        Args: Record<PropertyKey, never>
-        Returns: {
-          created_at: string
-          created_by: string
-          id: string
-          image_url: string
-          name: string
-          servings: number
-          steps: string[]
-        }[]
-      }
-      get_public_recipes: {
-        Args: Record<PropertyKey, never>
-        Returns: {
-          created_at: string
-          created_by: string
-          id: string
-          image_url: string
-          name: string
-          servings: number
-          steps: string[]
-        }[]
-      }
-      regenerate_grocery_list_items: {
-        Args: { list_id: string }
-        Returns: undefined
-      }
-      remove_recipe_from_grocery_list: {
-        Args: { list_id: string; recipe_id: number }
-        Returns: boolean
-      }
-      trigger_delete_old_anonymous_users: {
-        Args: Record<PropertyKey, never>
+      replace_generated_grocery_list_items: {
+        Args: { p_items: Json; p_list_id: string }
         Returns: undefined
       }
     }


### PR DESCRIPTION
## Context

Finalizes the Postgres → app-layer migration ("Migration B"). After `supabase/migrations/20260611130000_drop_ported_postgres_logic.sql` drops the ported SQL logic, the generated types and docs need to catch up.

## Changes

- **`src/types/database-types.ts`** — regenerated via `npm run gen-types`:
  - Removes the dropped SQL functions (`add_recipe_to_grocery_list`, `add_manual_item_to_grocery_list`, `find_best_unit_for_quantity`, `get_public_recipes`, `regenerate_grocery_list_items`, etc.) and the `units_backup_before_fix` table.
  - Adds `units.cooking_priority` and the `replace_generated_grocery_list_items` wrapper.
- **`CLAUDE.md`** — removes the now-obsolete Migration B transition note.

## ⚠️ Merge/deploy prerequisite

This assumes `20260611130000_drop_ported_postgres_logic.sql` has been **applied to the database**. If the migration isn't applied yet (it was deferred until soak), the regenerated types would be ahead of the live schema — apply the migration first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)